### PR TITLE
[Issue-4] com.day.cq.widget.HtmlLibraryManager not supported after 6.1

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/akamai/replication/components/akamai/akamai.jsp
+++ b/ui.apps/src/main/content/jcr_root/apps/akamai/replication/components/akamai/akamai.jsp
@@ -21,7 +21,7 @@
                     com.day.cq.replication.AgentConfig,
                     com.day.cq.replication.AgentManager,
                     com.day.cq.replication.ReplicationQueue,
-                    com.day.cq.widget.HtmlLibraryManager,
+                    com.adobe.granite.ui.clientlibs.HtmlLibraryManager,
                     com.day.cq.i18n.I18n" %><%
 %><%@include file="/libs/foundation/global.jsp"%><%
     I18n i18n = new I18n(slingRequest);


### PR DESCRIPTION
https://github.com/nateyolles/aem-akamai-replication-agent/issues/4